### PR TITLE
Fix load shedding

### DIFF
--- a/config_kz.yaml
+++ b/config_kz.yaml
@@ -174,7 +174,7 @@ lines:
   under_construction: "zero" # 'zero': set capacity to zero, 'remove': remove, 'keep': with full capacity
   modify_lines:
     limit_line_capacities: true # limiting line capacities
-    bus_of_interest: ["KZ.11_1_AC", "KZ.14_1_AC", "KZ.3_1_AC"] # buses of interest whose lines are limited
+    bus_of_interest: ["KZ.1_1_AC", "KZ.9_1_AC"] # buses of interest whose lines are limited
     max_limit: 700.0 # maximum limit for s_nom
 
 links:


### PR DESCRIPTION
Good day, here I propose changing the buses whose lines are limited. `KZ.1_1_AC` and `KZ.9_1_AC` are coal dominant buses. This helps to resolve the load shedding problem.