### PR TITLE
Fix cutout problem

### DIFF
--- a/config_kz_2011.yaml
+++ b/config_kz_2011.yaml
@@ -16,6 +16,9 @@ load_options:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount10.yaml
+++ b/config_kz_2011_discount10.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount10_coalexit.yaml
+++ b/config_kz_2011_discount10_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount15.yaml
+++ b/config_kz_2011_discount15.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount15_coalexit.yaml
+++ b/config_kz_2011_discount15_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount20.yaml
+++ b/config_kz_2011_discount20.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2011_discount20_coalexit.yaml
+++ b/config_kz_2011_discount20_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2011-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013.yaml
+++ b/config_kz_2013.yaml
@@ -16,6 +16,9 @@ load_options:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount10.yaml
+++ b/config_kz_2013_discount10.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount10_coalexit.yaml
+++ b/config_kz_2013_discount10_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount15.yaml
+++ b/config_kz_2013_discount15.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount15_coalexit.yaml
+++ b/config_kz_2013_discount15_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount20.yaml
+++ b/config_kz_2013_discount20.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2013_discount20_coalexit.yaml
+++ b/config_kz_2013_discount20_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2013-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018.yaml
+++ b/config_kz_2018.yaml
@@ -16,6 +16,9 @@ load_options:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount10.yaml
+++ b/config_kz_2018_discount10.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount10_coalexit.yaml
+++ b/config_kz_2018_discount10_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount15.yaml
+++ b/config_kz_2018_discount15.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount15_coalexit.yaml
+++ b/config_kz_2018_discount15_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount20.yaml
+++ b/config_kz_2018_discount20.yaml
@@ -25,6 +25,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:

--- a/config_kz_2018_discount20_coalexit.yaml
+++ b/config_kz_2018_discount20_coalexit.yaml
@@ -26,6 +26,9 @@ electricity:
 atlite:
   cutouts:
     asia-2018-era5:
+      module: era5
+      dx: 0.3  # cutout resolution
+      dy: 0.3  # cutout resolution
 
 renewable:
   onwind:


### PR DESCRIPTION
Here, I propose addition of 
`module: era5`
    `dx: 0.3  # cutout resolution`
    `dy: 0.3  # cutout resolution`
into the config files, because if the cutouts are not built (i.e. a first run), then the cutouts cannot be built. This issue was not observed previously, since all cutouts were built beforehand using different configs.