### PR TITLE
Modifications for coal exit scenario

### DIFF
--- a/scripts/modify_demand.py
+++ b/scripts/modify_demand.py
@@ -49,6 +49,11 @@ def rescale_load(n, gadm_demand):
         n.loads_t.p_set.loc[:,official_demand.index] * scale_factor.loc[official_demand.index]
     )
 
+    if True in n.generators.query("carrier=='coal'").p_nom_extendable.unique():
+        n.generators.loc[n.generators.carrier=="coal","p_nom_max"] = n.generators.loc[n.generators.carrier=="coal","p_nom"]
+        n.generators.loc[n.generators.carrier=="coal", "p_nom"] = 0
+        n.generators.loc[n.generators.carrier=="coal", "p_nom_min"] = 0
+
 
 if __name__ == "__main__":
     if "snakemake" not in globals():


### PR DESCRIPTION
Good day, here I propose a PR where `modify_demand` rule is modified, so that during coal exit scenario, the `p_nom_max` of coal-based plants are sent to current `p_nom`, while the `p_nom` and `p_nom_min` are set to zero. By making coal extendable it is possible to identify the optimal capacity of coal and avoid hude load shedding present before. Btw, I will add config files also here as soon as I check them.