### PR TITLE
fix custom rule based on recent changes

### DIFF
--- a/kz.smk
+++ b/kz.smk
@@ -50,6 +50,9 @@ def memory(w):
 
 
 rule solve_network_dle:
+    params:
+        solving=config["solving"],
+        augmented_line_connection=config["augmented_line_connection"],
     input:
         "networks/" + RDIR + "elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_dle.nc",
     output:


### PR DESCRIPTION
Good day, I propose changes to `solve_network_dle` rule `kz.smk` file to meet recent changes in Snakefile of PyPSA-Earth. In particular, in solve network, params were given in the snakefile. 