### PR TITLE
Change trigger branch to main

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -3,10 +3,10 @@ name: CI-Linux
 on:
   push:
     branches:
-    - scenario_management
+    - main
   pull_request:
     branches:
-    - scenario_management
+    - main
   schedule:
   - cron: "0 5 * * TUE"
 


### PR DESCRIPTION
Good day. Here, I propose changes in the CI linux. In particular, triggering branch is changed from `scenario_management` to `main`.